### PR TITLE
Build and deploy to https://support-dashboard.red-gate.com

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+config.yml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM ruby:2.6-alpine
+WORKDIR /app
+RUN apk add --no-cache build-base tzdata nodejs
+RUN gem install smashing zendesk_api
+COPY Gemfile* /app/
+RUN bundle install
+COPY . /app/
+ENTRYPOINT [ "smashing" ]
+CMD [ "start" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM ruby:2.6-alpine
 WORKDIR /app
 RUN apk add --no-cache build-base tzdata nodejs
-RUN gem install smashing zendesk_api
+RUN gem install bundler
 COPY Gemfile* /app/
 RUN bundle install
 COPY . /app/

--- a/README.md
+++ b/README.md
@@ -3,12 +3,26 @@ Dashboards for the Product Support team
 
 These are built on Ruby and Smashing (https://smashing.github.io/).
 
-Currently live on ps-russelld but I will move them to a proper deployment soon™.
+* Available at https://support-dashboard.red-gate.com
+* [Teamcity build](https://buildserver.red-gate.com/buildConfiguration/Dna_ProductSupport_Dashboard)
+* [Octopus Deploy project](https://octopus.red-gate.com/app#/projects/support-dashboard/overview)
 
 ## Settings
 Settings required to run are stored in a separate config.yml file. You will need to create this file locally in the root directory.
 
-### This requires:
-* url : "https://pathto.zendesk.com/api/v2" eg https://redgatesupport.zendesk.com/api/v2
-* username : "zendesk username"
-* token : "zendesk api token"
+### Example config.yml:
+
+```yaml
+---
+username: "zendesk username"
+token: "zendesk api token"
+```
+
+## How to build and run
+
+### Using docker
+
+```shell
+docker build -t support-dashboard
+docker run --rm -p 3030:3030 -e "zendesk_username=zendesk username" -e "zendesk_token=zendesk api token" support-dashboard
+```

--- a/jobs/zendeskviewcounts.rb
+++ b/jobs/zendeskviewcounts.rb
@@ -2,10 +2,17 @@ require 'yaml'
 require 'zendesk_api'
 
 client = ZendeskAPI::Client.new do |config|
-  configobject = YAML.load_file("config.yml")
-  config.url = configobject['url']
-  config.username = configobject['username']
-  config.token = configobject['token']
+  if File.file?("config.yml")
+    configobject = YAML.load_file("config.yml")
+    config.username = configobject['username']
+    config.token = configobject['token']
+  else
+    # No config file. Let's load from some environment variables.
+    # Easier to configure when deploying docker containers from octopus.
+    config.username = ENV['zendesk_username']
+    config.token = ENV['zendesk_token']
+  end
+  config.url = "https://redgatesupport.zendesk.com/api/v2"
   config.retry = true
 end
 
@@ -17,7 +24,7 @@ end
   # 29311566 - inbox (new)
   # 75065288 - 2 hours to breach
   # 360102654454 - urgent open
-  
+
   # Internal Escalations
   # 163887427 - internal escalations (all time)
   # 360016776498 - Internal escalations in the last month


### PR DESCRIPTION
Let's use docker since that's what we did for https://github.com/red-gate/flyway-dashboard/ and it's working all right.

To make life easier, I made some changes to allow setting the zendesk username/token via environment variables if `config.yml` isn't found. This should make it easier to deploy the container via octopus